### PR TITLE
Landing page hero & CTA copy update

### DIFF
--- a/lib/components/IndexHero.jsx
+++ b/lib/components/IndexHero.jsx
@@ -28,11 +28,11 @@ export const IndexHero = (props) => {
           <div className='relative hero-text-left mb-12 sm:mb-0'>
             <div className='w-3/4 xs:w-7/12 sm:w-full mx-auto'>
               <ReactFitty className='font-bold leading-none text-center'>
-                <span className='text-flashy'>Win</span> simply by
+                <span className='text-flashy'>Save, pool funds,</span>
               </ReactFitty>
 
               <ReactFitty className='mt-2 font-bold leading-none text-center'>
-                <span className='text-flashy'>saving your money</span>
+                <span className='text-flashy'>& win prizes together</span>
               </ReactFitty>
 
               <div className='text-center mt-6 sm:mt-12'>
@@ -42,7 +42,7 @@ export const IndexHero = (props) => {
                   href='https://app.pooltogether.com'
                   as='https://app.pooltogether.com'
                 >
-                  Deposit now
+                  Join the Pool
                 </ButtonLink>
               </div>
             </div>

--- a/lib/components/TVLAndWeeklyPrizesBanner.jsx
+++ b/lib/components/TVLAndWeeklyPrizesBanner.jsx
@@ -41,7 +41,7 @@ export const TVLAndWeeklyPrizesBanner = (props) => {
         <img src={Rocket} className='w-12 h-12 xs:w-16 xs:h-16 sm:mr-4' />
 
         <span className='sm:leading-tight text-xs xs:text-sm sm:text-lg lg:text-xl sm:mr-auto'>
-          Currently awarding {totalPrizeFormatted} in prizes weekly!
+          {totalPrizeFormatted} in interest awarded to pool members weekly!
         </span>
       </div>
     </div>


### PR DESCRIPTION
I joined the weekly Swim Meet call today, and @lay2000lbs & team described wanting to make the homepage feel more credible and trustworthy to new users. I mocked up a quick copy edit I thought would help, and team suggested I make a PR! 

The copy update changes the emphasis on the hero copy from winning prizes to saving together. I also changed "Deposit Now" to the friendlier "Join the Pool", and I adjusted the TVLAndWeeklyPrizesBanner copy to match as it was the only other thing above the fold.

<img width="878" alt="Screen Shot 2021-05-28 at 7 38 12 PM" src="https://user-images.githubusercontent.com/8751378/120050929-99e46000-bfec-11eb-88a3-4c912b731abe.png">

It feels amazing to be invited to make a PR right after joining my first community call! What a welcoming community!